### PR TITLE
Adapted to automatically find enclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,29 +22,30 @@ This fork looks up the ThinkServer Enclosure automatically.  Works when the devi
 
 Use `fancontrol.py` to set the fan speed:
 
-    # python fancontrol.py 2
+    # python fancontrol.py 1
     Enclosure not found on /dev/sg8
     Enclosure not found on /dev/sg7
     Enclosure found on /dev/sg6
-    Fan 0 speed: 0
-    Fan 1 speed: 947
-    Fan 2 speed: 932
-    Fan 3 speed: 812
-    Fan 4 speed: 932
-    Fan 5 speed: 947
+    Fan 0 speed: 1193
+    Fan 1 speed: 1205
+    Fan 2 speed: 1171
+    Fan 3 speed: 1217
+    Fan 4 speed: 1181
+    Fan 5 speed: 1218
     Reading current configuration...
-    Setting fan 0 to 2
-    Setting fan 1 to 2
-    Setting fan 2 to 2
-    Setting fan 3 to 2
-    Setting fan 4 to 2
-    Setting fan 5 to 2
-      LENOVO    ThinkServerSA120  1007
+    Setting fan 0 to 1
+    Setting fan 1 to 1
+    Setting fan 2 to 1
+    Setting fan 3 to 1
+    Setting fan 4 to 1
+    Setting fan 5 to 1
+    Set fan speeds... Waiting to get fan speeds (ctrl+c to skip)
+      LENOVO    ThinkServerSA120  1008
     Sending Enclosure Control [0x2] page, with page length=296 bytes
 
-    Fan 0 speed: 0
-    Fan 1 speed: 945
-    Fan 2 speed: 932
-    Fan 3 speed: 812
-    Fan 4 speed: 926
-    Fan 5 speed: 945
+    Fan 0 speed: 440
+    Fan 1 speed: 596
+    Fan 2 speed: 593
+    Fan 3 speed: 449
+    Fan 4 speed: 583
+    Fan 5 speed: 607

--- a/README.md
+++ b/README.md
@@ -18,20 +18,14 @@ FreeNAS 9.10 includes `sg_ses` as part of the standard image.
 
 ## Usage
 
-Find the SCSI Enclosure Services device corresponding to your SA120. On Linux, this is likely one of the `/dev/sg*` devices. (Try `lsscsi`?) On FreeBSD, this is likely `/dev/ses*` instead.
+This fork looks up the ThinkServer Enclosure automatically.  Works when the devices are either `/dev/sg*` or `/dev/ses*`
 
-You can use `sg_ses` to identify SES devices, e.g.:
+Use `fancontrol.py` to set the fan speed:
 
-    # sg_ses /dev/ses0
-      LSI CORP  SAS2X28           0717
-    …
-    # sg_ses /dev/ses1
-      LENOVO    ThinkServerSA120  1007
-    …
-
-Once you've found your SA120, use `fancontrol.py` to set the fan speed:
-
-    # python fancontrol.py /dev/sg0 2
+    # python fancontrol.py 2
+    Enclosure not found on /dev/sg8
+    Enclosure not found on /dev/sg7
+    Enclosure found on /dev/sg6
     Fan 0 speed: 0
     Fan 1 speed: 947
     Fan 2 speed: 932
@@ -54,4 +48,3 @@ Once you've found your SA120, use `fancontrol.py` to set the fan speed:
     Fan 3 speed: 812
     Fan 4 speed: 926
     Fan 5 speed: 945
-

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ FreeNAS 9.10 includes `sg_ses` as part of the standard image.
 
 ## Usage
 
-This fork looks up the ThinkServer Enclosure automatically.  Works when the devices are either `/dev/sg*` or `/dev/ses*`
+Finds the ThinkServer Enclosure automatically.  Works when the devices are either `/dev/sg*` or `/dev/ses*`
 
 Use `fancontrol.py` to set the fan speed:
 

--- a/fancontrol.py
+++ b/fancontrol.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import sys
 import time
+import glob
+
 try:
     from StringIO import StringIO
 except ImportError:
@@ -11,15 +13,35 @@ def print_speeds(device):
   for i in range(0, 6):
     print("Fan {} speed: {}".format(i, check_output(['sg_ses', '--index=coo,{}'.format(i), '--get=1:2:11', device]).decode('utf-8').split('\n')[0]))
 
-if len(sys.argv) < 2:
-  print("python fancontrol.py /dev/sgX 1-7")
+if len(sys.argv) < 1:
+  print("python fancontrol.py 1-7")
   sys.exit(-1)
 
-device = sys.argv[1]
-fan = int(sys.argv[2])
+fan = int(sys.argv[1])
 
 if fan <= 0 or fan > 6:
   raise Exception("Fan speed must be between 1 and 7")
+
+
+devices_to_check = ['/dev/sg*','/dev/ses*']
+
+device = ""
+
+for chk_device in devices_to_check:
+  for dev_node in glob.glob(chk_device):
+    try:
+      out = check_output(["sg_ses", dev_node], stderr=STDOUT)
+      if 'ThinkServerSA120' in out:
+        device = dev_node
+        break
+    except:
+      print("Enclosure not found on " + dev_node)
+
+if device == "":
+  print("Could not find enclosure")
+  sys.exit(1)
+
+print("Enclosure found on " + device);
 
 print_speeds(device)
 print("Reading current configuration...")


### PR DESCRIPTION
I adapted the code to automatically search for the enclosure, as my enclosure device would change on reboot.  

Tied to the device either being on /dev/sg or /dev/ses