### PR TITLE
Added maximum request length to ses command

### DIFF
--- a/fancontrol.py
+++ b/fancontrol.py
@@ -11,7 +11,7 @@ from subprocess import check_output, Popen, PIPE, STDOUT
 
 def print_speeds(device):
   for i in range(0, 6):
-    print("Fan {} speed: {}".format(i, check_output(['sg_ses', '--index=coo,{}'.format(i), '--get=1:2:11', device]).decode('utf-8').split('\n')[0]))
+    print("Fan {} speed: {}".format(i, check_output(['sg_ses', '--maxlen=32768', '--index=coo,{}'.format(i), '--get=1:2:11', device]).decode('utf-8').split('\n')[0]))
 
 if len(sys.argv) < 1:
   print("python fancontrol.py 1-7")
@@ -30,14 +30,14 @@ device = ""
 for chk_device in devices_to_check:
   for dev_node in glob.glob(chk_device):
     try:
-      out = check_output(["sg_ses", dev_node], stderr=STDOUT)
+      out = check_output(["sg_ses", '--maxlen=32768', dev_node], stderr=STDOUT)
       if 'ThinkServerSA120' in out:
         device = dev_node
 	print("Enclosure found on " + device);
 
 	print_speeds(device)
 	print("Reading current configuration...")
-	out = check_output(["sg_ses", "-p", "0x2", device, "--raw"]).decode('utf-8')
+	out = check_output(["sg_ses", '--maxlen=32768', "-p", "0x2", device, "--raw"]).decode('utf-8')
 	s = out.split()
 
 	for i in range(0, 6):
@@ -68,7 +68,7 @@ for chk_device in devices_to_check:
 	    break
 
 	output.write("\n")
-	p = Popen(['sg_ses', '-p', '0x2', device, '--control', '--data', '-'], stdout=PIPE, stdin=PIPE, stderr=PIPE)
+	p = Popen(['sg_ses', '--maxlen=32768', '-p', '0x2', device, '--control', '--data', '-'], stdout=PIPE, stdin=PIPE, stderr=PIPE)
 	print("Set fan speeds... Waiting to get fan speeds (ctrl+c to skip)")
 	print(p.communicate(input=bytearray(output.getvalue(), 'utf-8'))[0].decode('utf-8'))
 	time.sleep(10)


### PR DESCRIPTION
In some cases and on some operating systems, the enclosure is unable to deal with a response length longer that 65535 bytes. If the response is longer than this allowed limit, then the request is terminated. This happens at the sg_ses command level, so the fancontrol utility obviously cannot proceed. The issue is documented by the sg3_utils group on their [FreeBSD readme](https://github.com/hreinecke/sg3_utils/blob/master/README.freebsd) file.

This request modifies the command the stipulate a maximum length of 32kb so that it does not ever overflow the memory buffer. This problem was discovered and the solution created on a FreeNAS 10.0.2 system, but it could affect any systems with the sg_ses command and older or limited hardware.

I do not have a Linux system handy to test that this additional argument does not break the sg_ses output on something besides BSD, but I do not suspect that it will hurt anything if this command is _not_ needed by some systems.