### PR TITLE
Adding Solaris/illumos/OmniOS CE/etc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ FreeBSD systems via `pkg`:
 
 FreeNAS 9.10 includes `sg_ses` as part of the standard image.
 
+Solaris/OmniOS/OpenIndiana/SmartOS based systems:
+
+Native Solaris should have sg3_utils installed.  If executing `sg_ses` doesn't exist, it's necessary to install it from source.  Installing napp-it, for the ZFS GUI, also installed all the requisite development tools.  
+
+On OmniOS CE, the steps involved were:
+
+    * Download the package[the `sg3_utils` package](http://sg.danny.cz/sg/          sg3_utils.html).  Move to somewhere like `/root` and extract.
+    * Change into the directory, configure with `./configure --prefix=/root/sg3_utils`. 
+    * `make` && `make install`
+    * Run the fan script and set the path in the environment `sg_sess_path=/root/sg3_utils/bin/sg_ses python fancontrol.py 2`
+
+
+
 ## Usage
 
 Finds the ThinkServer Enclosure automatically. Works when the devices are either `/dev/sg*`, `/dev/ses*`, or `/dev/bsg/*`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Native Solaris should have sg3_utils installed.  If executing `sg_ses` doesn't e
 
 On OmniOS CE, the steps involved were:
 
-* Download the package[the `sg3_utils` package](http://sg.danny.cz/sg/          sg3_utils.html).  Move to somewhere like `/root` and extract.
+* Download [the `sg3_utils` package](http://sg.danny.cz/sg/sg3_utils.html).  Move to somewhere like `/root` and extract.
 * Change into the directory, configure with `./configure --prefix=/root/sg3_utils`. 
 * `make` && `make install`
 * Run the fan script and set the path in the environment `sg_sess_path=/root/sg3_utils/bin/sg_ses python fancontrol.py 2`

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Native Solaris should have sg3_utils installed.  If executing `sg_ses` doesn't e
 
 On OmniOS CE, the steps involved were:
 
-    * Download the package[the `sg3_utils` package](http://sg.danny.cz/sg/          sg3_utils.html).  Move to somewhere like `/root` and extract.
-    * Change into the directory, configure with `./configure --prefix=/root/sg3_utils`. 
-    * `make` && `make install`
-    * Run the fan script and set the path in the environment `sg_sess_path=/root/sg3_utils/bin/sg_ses python fancontrol.py 2`
+* Download the package[the `sg3_utils` package](http://sg.danny.cz/sg/          sg3_utils.html).  Move to somewhere like `/root` and extract.
+* Change into the directory, configure with `./configure --prefix=/root/sg3_utils`. 
+* `make` && `make install`
+* Run the fan script and set the path in the environment `sg_sess_path=/root/sg3_utils/bin/sg_ses python fancontrol.py 2`
 
 
 


### PR DESCRIPTION
Major changes here include:

* Instructions for getting running on an illumos-based server in README.
* Allow passing in the location of the `sg_ses` binary as an environment variable.
* Add the illumos/Solaris devices to the check array.
* Some try/catch around the device stat call that was imploding with the symbolic links on illumos.